### PR TITLE
fix: loading component behaviour for parameters

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -31,9 +31,9 @@ export function loadingComponentFactory(resolvableComponent, options) {
 
       return h(tag);
     },
-		directives: this.$vnode.data && this.$vnode.data.directives,
-		style: this.$vnode.data && [this.$vnode.data.style, this.$vnode.data.staticStyle],
-		class: this.$vnode.data && [
+		directives: process.server && this.$vnode.data && this.$vnode.data.directives,
+		style: process.server && this.$vnode.data && [this.$vnode.data.style, this.$vnode.data.staticStyle],
+		class: process.server && this.$vnode.data && [
 			this.$vnode.data.class,
 			this.$vnode.data.staticClass
 		],

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,9 +31,9 @@ export function loadingComponentFactory(resolvableComponent, options) {
 
       return h(tag);
     },
-		directives: process.server && this.$vnode.data && this.$vnode.data.directives,
-		style: process.server && this.$vnode.data && [this.$vnode.data.style, this.$vnode.data.staticStyle],
-		class: process.server && this.$vnode.data && [
+		directives: this.$vnode && this.$vnode.data && this.$vnode.data.directives,
+		style: this.$vnode && this.$vnode.data && [this.$vnode.data.style, this.$vnode.data.staticStyle],
+		class: this.$vnode && this.$vnode.data && [
 			this.$vnode.data.class,
 			this.$vnode.data.staticClass
 		],

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,6 +31,12 @@ export function loadingComponentFactory(resolvableComponent, options) {
 
       return h(tag);
     },
+		directives: this.$vnode.data && this.$vnode.data.directives,
+		style: this.$vnode.data && [this.$vnode.data.style, this.$vnode.data.staticStyle],
+		class: this.$vnode.data && [
+			this.$vnode.data.class,
+			this.$vnode.data.staticClass
+		],
     ...options,
   };
 }


### PR DESCRIPTION
e.g. you have a 
`<CustomComponentA class="xyz" />`

and CustomComponentA has 
`<div class="blub"></div>`  as template.

Currently only "xyz" is applied to SSR rendering, with this regular class merging is happening and the final result class is "xyz blub".

Same for style and v-show directive.

Reproducable example:
create a simple nuxt app, two files:
pages/test.vue:
```vue
<template>
	<div>
		<TestComponent class="additional-class">
			hallo
		</TestComponent>
	</div>
</template>

<script lang="ts">
import { Component, Vue } from 'vue-property-decorator';

import { hydrateOnInteraction } from 'vue-lazy-hydration';
@Component({
	name: 'TestPage',
	layout: 'none',
	components: {
		TestComponent: hydrateOnInteraction(() => import('~/components/Test.vue'), {
			ignoredProps: ['param1'],
			event: ['focus', 'click', 'touchstart', 'mouseover']
		})
	}
})
export default class CVPage extends Vue {}
</script>

```

and a simple components/Test.vue file
```vue
<template>
	<div class="inner-class">
		<slot>no slot value provided</slot>
	</div>
</template>
```

in this example I use the hydrate on interaction to see the "wrong" css class easier. Now without the patch following scenarios happen:
1. SSR (correct):
![image](https://user-images.githubusercontent.com/5757263/80815664-614a3b00-8bce-11ea-8312-0f280cc82ad7.png)

2. before hydration (wrong, this also causes some flickering):
![image](https://user-images.githubusercontent.com/5757263/80815697-6c9d6680-8bce-11ea-801f-226edf754de2.png)

3. after hydration (correct again):
![image](https://user-images.githubusercontent.com/5757263/80815717-7921bf00-8bce-11ea-9f78-08522e2af651.png)


this fix addresses step 2 (before hydration), by adding the necessary vnodes to the loading (placeholder) component. after adding this fix, step two look slike this (correct):
![image](https://user-images.githubusercontent.com/5757263/80815819-9ce50500-8bce-11ea-9815-c99268c2dc20.png)

@maoberlehner please let me know what you think of this issue.

thanks
simon