### PR TITLE
fix: do not hydrate single root elements

### DIFF
--- a/src/LazyHydrate.js
+++ b/src/LazyHydrate.js
@@ -154,7 +154,8 @@ export default {
     },
   },
   mounted() {
-    if (this.$el.childElementCount === 0) {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+    if (!this.$el || this.$el.nodeType !== 1) {
       // No SSR rendered content, hydrate immediately.
       this.hydrate();
       return;

--- a/test/integration/components/Integration.vue
+++ b/test/integration/components/Integration.vue
@@ -9,6 +9,9 @@
     <LazyHydrate ssr-only>
       <DummySsr/>
     </LazyHydrate>
+    <LazyHydrate ssr-only>
+      <SingleDummy/>
+    </LazyHydrate>
     <br>
     <br>
     <br>
@@ -92,6 +95,7 @@ import DummyIdle from './DummyIdle.vue';
 import DummyInteraction from './DummyInteraction.vue';
 import DummySsr from './DummySsr.vue';
 import DummyVisible from './DummyVisible.vue';
+import SingleDummy from './SingleDummy.vue';
 
 import LazyHydrate from '../../../src/LazyHydrate';
 
@@ -102,6 +106,7 @@ export default {
     DummyInteraction,
     DummySsr,
     DummyVisible,
+    SingleDummy,
     LazyHydrate,
   },
 };

--- a/test/integration/components/SingleDummy.vue
+++ b/test/integration/components/SingleDummy.vue
@@ -1,0 +1,23 @@
+<template>
+  <section class="SingleDummy">
+    <div
+      v-if="more"
+      class="more"
+    >
+      Just more.
+    </div>
+  </section>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        more: false,
+      };
+    },
+    mounted() {
+      this.more = true;
+    },
+  };
+</script>

--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -66,4 +66,16 @@ describe(`integration`, () => {
       expect(moreText).toBe(null);
     });
   });
+
+  describe(`hydration of single root items`, () => {
+    test(`It should not hydrate the component.`, async () => {
+      await open(`/integration.html`);
+
+      const component = await find(`.SingleDummy`);
+      expect(component).not.toBe(null);
+
+      const moreText = await page.$(`.SingleDummy .more`);
+      expect(moreText).toBe(null);
+    });
+  });
 });


### PR DESCRIPTION
e.g. I have a component with several v-if v-else-ifs and some other logic in there, but at the end it only exposes one single root element. due to the check of childElementCount this was always hydrated, even though it shouldn't. Checking for nodeType seems more reliable and is fully supported in all browsers.