### PR TITLE
passive event listener to make lighthouse best practices happy

### DIFF
--- a/src/LazyHydrate.js
+++ b/src/LazyHydrate.js
@@ -95,6 +95,7 @@ export function hydrateOnInteraction(component, { event = `focus`, ignoredProps 
         this.$el.addEventListener(eventName, resolvableComponent._resolve, {
           capture: true,
           once: true,
+          passive: true
         });
       });
     },


### PR DESCRIPTION
Running google lighthouse audits I'm getting the following issue reported:
<img width="878" alt="Screen Shot 2020-05-12 at 9 16 25 PM" src="https://user-images.githubusercontent.com/7635209/81764261-c89da000-9496-11ea-94f7-c6a701f7af8b.png">

From what I can tell from the [learn more link](https://web.dev/uses-passive-event-listeners/?utm_source=lighthouse&utm_medium=devtools) events can be passive unless they have the possibility of preventing the event (which I don't see why lazy hydration would need to do)

Marking as passive is supposed to be better for performance, from what I understand. 

Thanks!