### PR TITLE
Test that el is an Element

### DIFF
--- a/src/LazyHydrate.js
+++ b/src/LazyHydrate.js
@@ -154,7 +154,7 @@ export default {
     },
   },
   mounted() {
-    if (this.$el.childElementCount === 0) {
+    if (this.$el.childElementCount === 0 || this.$el.nodeType !== 1 ) {
       // No SSR rendered content, hydrate immediately.
       this.hydrate();
       return;


### PR DESCRIPTION
This is a simplification of the changes proposed in #51, specifically [this line](https://github.com/maoberlehner/vue-lazy-hydration/pull/51/files#diff-9ee912fff619b8179fbe3c636afcbd8aR160).

My use case was a scenario like this:

```vue
<lazy-hydrate when-visible>
  <my-component v-if='false'></my-component>
</lazy-hydrate>
```

In this case, `this.$el.` is a [Comment](https://developer.mozilla.org/en-US/docs/Web/API/Comment) and throws this error:

> TypeError: Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is not of type 'Element'.

... on [this line](https://github.com/maoberlehner/vue-lazy-hydration/blob/master/src/LazyHydrate.js#L206).