### PR TITLE
Add `passive` attribute to scrolling events

### DIFF
--- a/src/LazyHydrate.js
+++ b/src/LazyHydrate.js
@@ -94,7 +94,7 @@ export function hydrateOnInteraction(component, { event = `focus`, ignoredProps 
           capture: true,
           once: true,
         }
-      const passiveListenerEvents = ['touchstart', 'touchmove']
+      const passiveListenerEvents = ['touchstart', 'touchmove', 'scroll', 'wheel', 'touchend']
       events.forEach((eventName) => {
         // eslint-disable-next-line no-underscore-dangle
         if(passiveListenerEvents.includes(eventName)) eventOptions.passive = true

--- a/src/LazyHydrate.js
+++ b/src/LazyHydrate.js
@@ -90,12 +90,15 @@ export function hydrateOnInteraction(component, { event = `focus`, ignoredProps 
   const loading = loadingComponentFactory(resolvableComponent, {
     props: ignoredProps,
     mounted() {
-      events.forEach((eventName) => {
-        // eslint-disable-next-line no-underscore-dangle
-        this.$el.addEventListener(eventName, resolvableComponent._resolve, {
+      const eventOptions = {
           capture: true,
           once: true,
-        });
+        }
+      const passiveListenerEvents = ['touchstart', 'touchmove']
+      events.forEach((eventName) => {
+        // eslint-disable-next-line no-underscore-dangle
+        if(passiveListenerEvents.includes(eventName)) eventOptions.passive = true
+        this.$el.addEventListener(eventName, resolvableComponent._resolve, eventOptions);
       });
     },
   });


### PR DESCRIPTION
Adding a passive attribute to scrolling events: touchstart and touchmove.
Adding more soon. 
