### PR TITLE
Fix hydration blocker attributes forwarding

### DIFF
--- a/src/utils/hydration-blocker.js
+++ b/src/utils/hydration-blocker.js
@@ -83,7 +83,7 @@ export function makeHydrationBlocker(component, options) {
       },
       render(h) {
         return h(this.Nonce, {
-          attrs: this.$attrs,
+          attrs: Object.assign({}, this.$attrs),
           on: this.$listeners,
           scopedSlots: this.$scopedSlots,
         }, this.$slots.default);


### PR DESCRIPTION
Fixes #96

Copies attributes like `v-bind="$attrs"` would do. 

`v-bind="$attrs"` compiles to:
```js
bindObjectProps({}, 'tag', v._$attrs, false)
```

See [bindObjectProps](https://github.com/vuejs/vue/blob/0603ff695d2f41286239298210113cbe2b209e28/src/core/instance/render-helpers/bind-object-props.js#L17)