### PR TITLE
Disable hydration after full page load

### DIFF
--- a/src/LazyHydrate.js
+++ b/src/LazyHydrate.js
@@ -78,7 +78,7 @@ export default makeHydrationBlocker(Placeholder, {
     triggerHydration: {
       immediate: true,
       handler(isTriggered) {
-        if (isTriggered) this.hydrate();
+        if (isTriggered && this.hydrate) this.hydrate();
       },
     },
   },

--- a/src/utils/disabled.js
+++ b/src/utils/disabled.js
@@ -1,0 +1,16 @@
+const isServer = typeof window === `undefined`;
+let isPageLodaded = false;
+
+if (!isServer) {
+  // load event fires, when document with all scripts is loaded,
+  // so after hydration process is finished
+  window.addEventListener(`load`, () => {
+    isPageLodaded = true;
+  });
+}
+
+export function isHydrationDisabled() {
+  // Hydration may be disabled because we are in SSR context
+  // or page was fully loaded & hydrated, so it's not needed anymore
+  return isServer || isPageLodaded;
+}

--- a/src/utils/hydration-blocker.js
+++ b/src/utils/hydration-blocker.js
@@ -1,21 +1,30 @@
 import { makeHydrationObserver } from './hydration-observer';
 import { makeHydrationPromise } from './hydration-promise';
 import { makeNonce } from './nonce';
+import { isHydrationDisabled } from './disabled';
 
 export function makeHydrationBlocker(component, options) {
   return Object.assign({
     mixins: [{
       beforeCreate() {
         this.cleanupHandlers = [];
-        const { hydrate, hydrationPromise } = makeHydrationPromise();
-        this.Nonce = makeNonce({ component, hydrationPromise });
-        this.hydrate = hydrate;
-        this.hydrationPromise = hydrationPromise;
+
+        if (isHydrationDisabled()) {
+          this.Nonce = component;
+        } else {
+          const { hydrate, hydrationPromise } = makeHydrationPromise();
+          this.Nonce = makeNonce({ component, hydrationPromise });
+          this.hydrate = hydrate;
+          this.hydrationPromise = hydrationPromise;
+        }
       },
       beforeDestroy() {
         this.cleanup();
       },
       mounted() {
+        // hydration is disabled
+        if (!this.hydrate) return;
+
         if (this.$el.nodeType === Node.COMMENT_NODE) {
           // No SSR rendered content, hydrate immediately.
           this.hydrate();

--- a/src/utils/nonce.js
+++ b/src/utils/nonce.js
@@ -1,5 +1,3 @@
-const isServer = typeof window === `undefined`;
-
 function isAsyncComponentFactory(componentOrFactory) {
   return typeof componentOrFactory === `function`;
 }
@@ -12,7 +10,5 @@ function resolveComponent(componentOrFactory) {
 }
 
 export function makeNonce({ component, hydrationPromise }) {
-  if (isServer) return component;
-
   return () => hydrationPromise.then(() => resolveComponent(component));
 }


### PR DESCRIPTION
Some time ago I filled an issue https://github.com/maoberlehner/vue-lazy-hydration/issues/88

I found that an easy way to fix this is to disable the hydration once the page is fully loaded and all hydration is finished.
Once you complete the hydration any further navigation will happen in SPA mode, so no more hydration will ever occur.
Also, it may have some additional performance benefit, because we don't have to mount IntersectionObservers or idle callbacks when they are not needed anymore.